### PR TITLE
Fixed/balanced zombie pilot loot

### DIFF
--- a/data/json/monsterdrops/zombie_military_pilot.json
+++ b/data/json/monsterdrops/zombie_military_pilot.json
@@ -7,8 +7,7 @@
     "ammo": 60,
     "entries": [
       { "group": "clothing_military_pilot", "prob": 65, "damage-min": 1, "damage-max": 4 },
-      { "group": "gear_soldier_sidearm", "prob": 30, "damage-min": 1, "damage-max": 4 },
-      { "collection": [ { "group": "guns_pistol_milspec" }, { "item": "holster" } ] },
+      { "group": "gear_soldier_sidearm", "prob": 50, "damage-min": 1, "damage-max": 4 },
       { "item": "two_way_radio", "prob": 50, "damage-min": 1, "damage-max": 4 },
       { "item": "adderall", "prob": 40 },
       { "item": "id_military", "prob": 5 },


### PR DESCRIPTION
As per discord discussion, fixed zombie pilot loot. There were two checks for a handgun - one as per of the collection, one with some prob chance. Also holster could be doubled. Increased slightly non-guaranteed gun spawn chance as per Kybe's insistence.